### PR TITLE
easier support for setting default currency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build
 .project
 .pydevproject
 .settings
+.idea

--- a/src/moneyed/__init__.py
+++ b/src/moneyed/__init__.py
@@ -1,1 +1,13 @@
 from classes import *
+
+
+def set_default_currency(code):
+    global DEFAULT_CURRENCY_CODE
+    DEFAULT_CURRENCY_CODE = get_currency(code)
+
+
+class Money(Money):
+    def __init__(self, amount=Decimal('0.0'), currency=None):
+        if currency is None:
+            currency = DEFAULT_CURRENCY_CODE
+        super(Money, self).__init__(amount, currency)


### PR DESCRIPTION
Just implemented mini function within `src/__init__.py` in order to set default currency on "import moneyed" usage.

Example:
```
>>> import moneyed
>>> moneyed.set_default_currency('TRY')
>>> moneyed.Money('1.23')
1.23 TRY
```