### PR TITLE
switches to ISO 80000-1:2009 for default format

### DIFF
--- a/src/moneyed/localization.py
+++ b/src/moneyed/localization.py
@@ -130,7 +130,7 @@ _format = _FORMATTER.add_formatting_definition
 
 ## FORMATTING RULES
 
-_format(DEFAULT, group_size=3, group_separator=",", decimal_point=".",
+_format(DEFAULT, group_size=3, group_separator=" ", decimal_point=".",
                  positive_sign="", trailing_positive_sign="",
                  negative_sign="-", trailing_negative_sign="",
                  rounding_method=ROUND_HALF_EVEN)


### PR DESCRIPTION
ISO 80000-1:2009 specifies a whitespace or no group seperator at all,
to prevent dot and comma confusion.