### PR TITLE
Modified test_equality_to_other_types to make sure $0 is not the same as...

### DIFF
--- a/src/moneyed/test_moneyed_classes.py
+++ b/src/moneyed/test_moneyed_classes.py
@@ -163,9 +163,9 @@ class TestMoney:
         assert self.one_million_bucks != x
 
     def test_equality_to_other_types(self):
-        x = Money(amount=1, currency=self.USD)
-        assert self.one_million_bucks != None
-        assert self.one_million_bucks != {}
+        x = Money(amount=0, currency=self.USD)
+        assert x != None
+        assert x != {}
 
     def test_not_equal_to_decimal_types(self):
         assert self.one_million_bucks != self.one_million_decimal


### PR DESCRIPTION
... None or an empty dict. The previous version didn't make sense.