### PR TITLE
Adds eq method to Currency class

### DIFF
--- a/src/moneyed/classes.py
+++ b/src/moneyed/classes.py
@@ -33,6 +33,8 @@ class Currency(object):
                 (self.name == other.name) and
                 (self.numeric == other.numeric))
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 class MoneyComparisonError(TypeError):
     # This exception was needed often enough to merit its own

--- a/src/moneyed/classes.py
+++ b/src/moneyed/classes.py
@@ -26,6 +26,13 @@ class Currency(object):
     def __repr__(self):
         return self.code
 
+    def __eq__(self, other):
+        return (isinstance(other, Currency) and
+                (self.code == other.code) and
+                (self.countries == other.countries) and
+                (self.name == other.name) and
+                (self.numeric == other.numeric))
+
 
 class MoneyComparisonError(TypeError):
     # This exception was needed often enough to merit its own

--- a/src/moneyed/test_moneyed_classes.py
+++ b/src/moneyed/test_moneyed_classes.py
@@ -49,6 +49,7 @@ class TestCurrency:
         assert currency1 == currency2
         assert currency2 == currency1
         assert currency1 != currency3
+        assert not (currency1 != currency2)
 
     def test_repr(self):
         assert str(self.default_curr) == self.default_curr_code

--- a/src/moneyed/test_moneyed_classes.py
+++ b/src/moneyed/test_moneyed_classes.py
@@ -41,6 +41,15 @@ class TestCurrency:
         assert US_dollars.name == 'US Dollar'
         assert US_dollars.numeric == '840'
 
+    def test_equals(self):
+        currency1 = Currency(code='USD',numeric='840',name='US Dollar', countries =['UNITED STATES'])
+        currency2 = Currency(code='USD',numeric='840',name='US Dollar', countries =['UNITED STATES'])
+        currency3 = Currency(code='USD',numeric='840',name='US Dollar', countries =['UNITED STATES', 'PALAU'])
+
+        assert currency1 == currency2
+        assert currency2 == currency1
+        assert currency1 != currency3
+
     def test_repr(self):
         assert str(self.default_curr) == self.default_curr_code
 


### PR DESCRIPTION
This PR updates the Currency class to use a deep compare.

The fact that it doesn't currently use one causes problems when pickling/depickling Money objects.  Consider this case:
```
In [1]: import pickle
In [2]: import moneyed
In [3]: mm = moneyed.Money(100,'USD')
In [4]: m_new = pickle.loads(pickle.dumps(mm))
In [5]: mm == m_new
Out[5]: False
```

It also adds unit tests