### PR TITLE
Deprecated automatic conversion from floats for * / % operations

### DIFF
--- a/src/moneyed/classes.py
+++ b/src/moneyed/classes.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import unicode_literals
 
 from decimal import Decimal, ROUND_DOWN
+import warnings
 
 # Default, non-existent, currency
 DEFAULT_CURRENCY_CODE = 'XYZ'
@@ -106,6 +107,8 @@ class Money(object):
         if isinstance(other, Money):
             raise TypeError('Cannot multiply two Money instances.')
         else:
+            if isinstance(other, float):
+                warnings.warn("Multiplying Money instances with floats is deprecated", DeprecationWarning)
             return Money(
                 amount=(self.amount * Decimal(str(other))),
                 currency=self.currency)
@@ -116,6 +119,8 @@ class Money(object):
                 raise TypeError('Cannot divide two different currencies.')
             return self.amount / other.amount
         else:
+            if isinstance(other, float):
+                warnings.warn("Dividing Money instances by floats is deprecated", DeprecationWarning)
             return Money(
                 amount=self.amount / Decimal(str(other)),
                 currency=self.currency)
@@ -138,6 +143,8 @@ class Money(object):
         if isinstance(other, Money):
             raise TypeError('Invalid __rmod__ operation')
         else:
+            if isinstance(other, float):
+                warnings.warn("Calculating percentages of Money instances using floats is deprecated", DeprecationWarning)
             return Money(
                 amount=(Decimal(str(other)) * self.amount / 100),
                 currency=self.currency)

--- a/src/moneyed/test_moneyed_classes.py
+++ b/src/moneyed/test_moneyed_classes.py
@@ -3,6 +3,8 @@
 from __future__ import division
 from __future__ import unicode_literals
 from decimal import Decimal
+import warnings
+
 import pytest  # Works with less code, more consistency than unittest.
 
 from moneyed.classes import Currency, Money, MoneyComparisonError, CURRENCIES, DEFAULT_CURRENCY
@@ -120,6 +122,18 @@ class TestMoney:
         assert 3 * x == Money(333.99, currency=self.USD)
         assert Money(333.99, currency=self.USD) == 3 * x
 
+    def test_mul_float_warning(self):
+        # This should be changed to TypeError exception after deprecation period is over.
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            Money(amount="10") * 1.2
+            assert "Multiplying Money instances with floats is deprecated" in [w.message.args[0] for w in warning_list]
+
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            1.2 * Money(amount="10")
+            assert "Multiplying Money instances with floats is deprecated" in [w.message.args[0] for w in warning_list]
+
     def test_mul_bad(self):
         with pytest.raises(TypeError):
             self.one_million_bucks * self.one_million_bucks
@@ -140,6 +154,13 @@ class TestMoney:
         y = 2
         assert x / y == Money(amount=25, currency=self.USD)
 
+    def test_div_float_warning(self):
+        # This should be changed to TypeError exception after deprecation period is over.
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            Money(amount="10") / 1.2
+            assert "Dividing Money instances by floats is deprecated" in [w.message.args[0] for w in warning_list]
+
     def test_rmod(self):
         assert 1 % self.one_million_bucks == Money(amount=10000,
                                                    currency=self.USD)
@@ -148,6 +169,13 @@ class TestMoney:
         with pytest.raises(TypeError):
             assert (self.one_million_bucks % self.one_million_bucks
                     == 1)
+
+    def test_rmod_float_warning(self):
+        # This should be changed to TypeError exception after deprecation period is over.
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            2.0 % Money(amount="10")
+            assert "Calculating percentages of Money instances using floats is deprecated" in [w.message.args[0] for w in warning_list]
 
     def test_convert_to_default(self):
         # Currency conversions are not implemented as of 2/2011; when


### PR DESCRIPTION
This addresses issue #39, and the other two places that did float conversions where the Decimal class would instead raise TypeError.

Once deprecation period is over, warnings should be changed to a TypeError. However, the best way to do this is probably just to remove the warning, and change `Decimal(str(other))` to `other`, and the underlying Decimal method will raise the appropriate exception (while still allowing things like integers to be used).