### PR TITLE
Make `Money` class open for extension

### DIFF
--- a/src/moneyed/classes.py
+++ b/src/moneyed/classes.py
@@ -78,12 +78,12 @@ class Money(object):
         return format_money(self)
 
     def __pos__(self):
-        return Money(
+        return self.__class__(
             amount=self.amount,
             currency=self.currency)
 
     def __neg__(self):
-        return Money(
+        return self.__class__(
             amount= -self.amount,
             currency=self.currency)
 
@@ -92,7 +92,7 @@ class Money(object):
             raise TypeError('Cannot add or subtract a ' +
                             'Money and non-Money instance.')
         if self.currency == other.currency:
-            return Money(
+            return self.__class__(
                 amount=self.amount + other.amount,
                 currency=self.currency)
 
@@ -106,7 +106,7 @@ class Money(object):
         if isinstance(other, Money):
             raise TypeError('Cannot multiply two Money instances.')
         else:
-            return Money(
+            return self.__class__(
                 amount=(self.amount * Decimal(str(other))),
                 currency=self.currency)
 
@@ -116,12 +116,12 @@ class Money(object):
                 raise TypeError('Cannot divide two different currencies.')
             return self.amount / other.amount
         else:
-            return Money(
+            return self.__class__(
                 amount=self.amount / Decimal(str(other)),
                 currency=self.currency)
 
     def __abs__(self):
-        return Money(
+        return self.__class__(
             amount=abs(self.amount),
             currency=self.currency)
 
@@ -138,7 +138,7 @@ class Money(object):
         if isinstance(other, Money):
             raise TypeError('Invalid __rmod__ operation')
         else:
-            return Money(
+            return self.__class__(
                 amount=(Decimal(str(other)) * self.amount / 100),
                 currency=self.currency)
 

--- a/src/moneyed/test_moneyed_classes.py
+++ b/src/moneyed/test_moneyed_classes.py
@@ -220,6 +220,19 @@ class TestMoney:
         operated_money = (50 % ExtendedMoney(amount=4, currency=self.USD))
         assert type(extended_money) == type(operated_money)
 
+    def test_can_call_subclass_method_after_arithmetic_operations(self):
+        """
+        Calls to `ExtendedMoney::do_my_behaviour` method throws
+        AttributeError: 'Money' object has no attribute 'do_my_behaviour'
+        if multiplication operator doesn't return subclass instance.
+        """
+
+        extended_money = ExtendedMoney(amount=2, currency=self.USD)
+        # no problem
+        extended_money.do_my_behaviour()
+        # throws error if `__mul__` doesn't return subclass instance
+        (1 * extended_money).do_my_behaviour()
+
 
 class ExtendedMoney(Money):
 

--- a/src/moneyed/test_moneyed_classes.py
+++ b/src/moneyed/test_moneyed_classes.py
@@ -194,3 +194,34 @@ class TestMoney:
         assert abs(x) == abs_money
         y = Money(amount=1, currency=self.USD)
         assert abs(x) == abs_money
+
+    def test_arithmetic_operations_return_real_subclass_instance(self):
+        """
+        Arithmetic operations on a subclass instance should return instances in the same subclass
+        type.
+        """
+
+        extended_money = ExtendedMoney(amount=2, currency=self.USD)
+
+        operated_money = +extended_money
+        assert type(extended_money) == type(operated_money)
+        operated_money = -extended_money
+        assert type(extended_money) == type(operated_money)
+        operated_money = ExtendedMoney(amount=1, currency=self.USD) + ExtendedMoney(amount=1, currency=self.USD)
+        assert type(extended_money) == type(operated_money)
+        operated_money = ExtendedMoney(amount=3, currency=self.USD) - Money(amount=1, currency=self.USD)
+        assert type(extended_money) == type(operated_money)
+        operated_money = (1 * extended_money)
+        assert type(extended_money) == type(operated_money)
+        operated_money = (extended_money / 1)
+        assert type(extended_money) == type(operated_money)
+        operated_money = abs(ExtendedMoney(amount=-2, currency=self.USD))
+        assert type(extended_money) == type(operated_money)
+        operated_money = (50 % ExtendedMoney(amount=4, currency=self.USD))
+        assert type(extended_money) == type(operated_money)
+
+
+class ExtendedMoney(Money):
+
+    def do_my_behaviour(self):
+        pass


### PR DESCRIPTION
Current `Money` implementation is not open to extension. Let's say I added a new method `xyz` to `ExtendedMoney` class which extends from `Money`.
This call is working without problem:
`ExtendedMoney(1, 'usd').do_my_behaviour()`
But if I use an arithmetic operation (such as `__mull__` or `__add__`), `Money` class returning `Money` instance instead of real polymorphic instance. As a result I cannot do this:
`(3 * ExtendedMoney(1, 'usd')).do_my_behaviour()` or `(ExdendedMoney(1, 'usd') + ExdendedMoney(2, 'usd')).do_my_behaviour()`
