### PR TITLE
Added support for decimal_places in currency format definition.

### DIFF
--- a/src/moneyed/localization.py
+++ b/src/moneyed/localization.py
@@ -23,7 +23,8 @@ class CurrencyFormatter(object):
                                   group_separator, decimal_point,
                                   positive_sign, trailing_positive_sign,
                                   negative_sign, trailing_negative_sign,
-                                  rounding_method):
+                                  rounding_method,
+                                  decimal_places=2):
         locale = locale.upper()
         self.formatting_definitions[locale] = {
             'group_size': group_size,
@@ -33,7 +34,8 @@ class CurrencyFormatter(object):
             'trailing_positive_sign': trailing_positive_sign,
             'negative_sign': negative_sign,
             'trailing_negative_sign': trailing_negative_sign,
-            'rounding_method': rounding_method}
+            'rounding_method': rounding_method,
+            'decimal_places': decimal_places}
 
     def get_sign_definition(self, currency_code, locale):
         currency_code = currency_code.upper()
@@ -66,8 +68,7 @@ class CurrencyFormatter(object):
             rounding_method = formatting['rounding_method']
 
         if decimal_places is None:
-            # TODO: Use individual defaults for each currency
-            decimal_places = 2
+            decimal_places = formatting['decimal_places']
 
         q = Decimal(10) ** -decimal_places  # 2 places --> '0.01'
         quantized = money.amount.quantize(q, rounding_method)


### PR DESCRIPTION
Hi! In many cases .format() is called without specifying decimal_places and it is nice to have a configurable default.
