### PR TITLE
Added support for GBP in en_GB locale

### DIFF
--- a/moneyed/localization.py
+++ b/moneyed/localization.py
@@ -165,6 +165,12 @@ _format("pl_PL", group_size=3, group_separator=" ", decimal_point=",",
         negative_sign="-", trailing_negative_sign="",
         rounding_method=ROUND_HALF_EVEN)
 
+_format("en_GB", group_size=3, group_separator=",", decimal_point=".",
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
+
 # CURRENCY SIGNS
 # Default currency signs. These can be overridden for locales where
 # foreign or local currency signs for one reason or another differ
@@ -325,7 +331,7 @@ _sign(DEFAULT, moneyed.ZMW, prefix='ZK')
 _sign(DEFAULT, moneyed.ZWL, prefix='Z$')
 
 _sign('en_US', moneyed.USD, prefix='$')
-_sign('en_UK', moneyed.GBP, prefix='£')
+_sign('en_GB', moneyed.GBP, prefix='£')
 _sign('sv_SE', moneyed.SEK, prefix=' kr')
 _sign('pl_PL', moneyed.PLN, suffix=' zł')
 _sign('de_DE', moneyed.EUR, suffix=' €')


### PR DESCRIPTION
Pymoneyed doesn't work correctly with localizing the GBP currency in the en_GB locale (United Kingdom):

    >>> from moneyed import Money, GBP, localization
    >>> localization.format_money(Money(10, GBP), locale='en_GB')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "moneyed/localization.py", line 66, in format
        rounding_method = formatting['rounding_method']
    TypeError: 'NoneType' object has no attribute '__getitem__'

This pull request fixes that.  (Note that as part of it, it corrects the mistake of defining the '£' sign for the `en_UK` locale, which is not a valid locale.  The correct locale is `en_GB`.)

It will now behave as:

    >>> from moneyed import Money, GBP, localization
    >>> localization.format_money(Money(10, GBP), locale='en_GB')
    u'\xa310.00'
    >>> print (localization.format_money(Money(10, GBP), locale='en_GB'))
    £10.00
    >>> print (localization.format_money(Money(10, GBP), locale='en_US'))
    10.00 GBP
    >>> print (localization.format_money(Money(10, GBP)))
    GB£10.00
