### PR TITLE
Fix get_formatting_definition() failing if locale is not found

### DIFF
--- a/moneyed/localization.py
+++ b/moneyed/localization.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from decimal import Decimal, ROUND_HALF_EVEN
 import moneyed
 
-DEFAULT = "default"
+DEFAULT = "DEFAULT"
 
 
 class CurrencyFormatter(object):
@@ -49,11 +49,9 @@ class CurrencyFormatter(object):
             return ('', " %s" % currency_code)
 
     def get_formatting_definition(self, locale):
-        locale = locale.upper()
-        if locale in self.formatting_definitions:
-            return self.formatting_definitions.get(locale)
-        else:
-            return self.formatting_definitions.get(DEFAULT)
+        if locale.upper() not in self.formatting_definitions:
+            locale = DEFAULT
+        return self.formatting_definitions.get(locale.upper())
 
     def format(self, money, include_symbol=True, locale=DEFAULT,
                decimal_places=None, rounding_method=None):

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -109,6 +109,8 @@ class TestMoney:
         assert format_money(self.one_million_bucks) == 'US$1,000,000.00'
         # No decimal point without fractional part
         assert format_money(self.one_million_bucks, decimal_places=0) == 'US$1,000,000'
+        # Locale format not included, should fallback to DEFAULT
+        assert format_money(self.one_million_bucks, locale='es_ES') == 'US$1,000,000.00'
         # locale == pl_PL
         one_million_pln = Money('1000000', 'PLN')
         # Two decimal places by default


### PR DESCRIPTION
Fallback to DEFAULT in get_formatting_definition() if not in formatting_definitions
