### PR TITLE
Removed unnecessary type casting of Decimals in multiplication and division

### DIFF
--- a/moneyed/classes.py
+++ b/moneyed/classes.py
@@ -13,6 +13,13 @@ DEFAULT_CURRENCY_CODE = 'XYZ'
 PYTHON2 = sys.version_info[0] == 2
 
 
+def force_decimal(amount):
+    """Given an amount of unknown type, type cast it to be a Decimal."""
+    if not isinstance(amount, Decimal):
+        return Decimal(str(amount))
+    return amount
+
+
 class Currency(object):
     """
     A Currency represents a form of money issued by governments, and
@@ -125,7 +132,7 @@ class Money(object):
             if isinstance(other, float):
                 warnings.warn("Multiplying Money instances with floats is deprecated", DeprecationWarning)
             return self.__class__(
-                amount=(self.amount * Decimal(str(other))),
+                amount=(self.amount * force_decimal(other)),
                 currency=self.currency)
 
     def __truediv__(self, other):
@@ -137,7 +144,7 @@ class Money(object):
             if isinstance(other, float):
                 warnings.warn("Dividing Money instances by floats is deprecated", DeprecationWarning)
             return self.__class__(
-                amount=self.amount / Decimal(str(other)),
+                amount=(self.amount / force_decimal(other)),
                 currency=self.currency)
 
     def __abs__(self):

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -8,10 +8,17 @@ from decimal import Decimal
 import warnings
 
 import pytest  # Works with less code, more consistency than unittest.
-from mock import patch
 
 from moneyed.classes import Currency, Money, MoneyComparisonError, CURRENCIES, DEFAULT_CURRENCY, USD, get_currency, force_decimal
 from moneyed.localization import format_money
+
+
+class CustomDecimal(Decimal):
+    """Test class to ensure Decimal.__str__ is not
+    used in calculations.
+    """
+    def __str__(self):
+        return 'error'
 
 
 class TestCurrency:
@@ -293,21 +300,17 @@ class TestMoney:
         assert force_decimal(53) == Decimal('53')
         assert force_decimal(Decimal('53.55')) == Decimal('53.55')
 
-    def test_decimal_not_cast_to_string_when_multiplying(self):
-        m = Money('531', self.USD)
-        a = Decimal('53.313')
-        with patch.object(Decimal, '__str__') as mock_str:
-            result = m * a
-            mock_str.assert_not_called()
-        assert result == Money('28309.203', self.USD)
+    def test_decimal_doesnt_use_str_when_multiplying(self):
+        m = Money('531', 'GBP')
+        a = CustomDecimal('53.313')
+        result = m * a
+        assert result == Money('28309.203', 'GBP')
 
-    def test_decimal_not_cast_to_string_when_dividing(self):
-        m = Money('15.60', self.USD)
-        a = Decimal('3.2')
-        with patch.object(Decimal, '__str__') as mock_str:
-            result = m / a
-            mock_str.assert_not_called()
-        assert result == Money('4.875', self.USD)
+    def test_decimal_doesnt_use_str_when_dividing(self):
+        m = Money('15.60', 'GBP')
+        a = CustomDecimal('3.2')
+        result = m / a
+        assert result == Money('4.875', 'GBP')
 
 
 class ExtendedMoney(Money):

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -8,8 +8,9 @@ from decimal import Decimal
 import warnings
 
 import pytest  # Works with less code, more consistency than unittest.
+from mock import patch
 
-from moneyed.classes import Currency, Money, MoneyComparisonError, CURRENCIES, DEFAULT_CURRENCY, USD, get_currency
+from moneyed.classes import Currency, Money, MoneyComparisonError, CURRENCIES, DEFAULT_CURRENCY, USD, get_currency, force_decimal
 from moneyed.localization import format_money
 
 
@@ -286,6 +287,27 @@ class TestMoney:
     def test_bool(self):
         assert bool(Money(amount=1, currency=self.USD))
         assert not bool(Money(amount=0, currency=self.USD))
+
+    def test_force_decimal(self):
+        assert force_decimal('53.55') == Decimal('53.55')
+        assert force_decimal(53) == Decimal('53')
+        assert force_decimal(Decimal('53.55')) == Decimal('53.55')
+
+    def test_decimal_not_cast_to_string_when_multiplying(self):
+        m = Money('531', self.USD)
+        a = Decimal('53.313')
+        with patch.object(Decimal, '__str__') as mock_str:
+            result = m * a
+            mock_str.assert_not_called()
+        assert result == Money('28309.203', self.USD)
+
+    def test_decimal_not_cast_to_string_when_dividing(self):
+        m = Money('15.60', self.USD)
+        a = Decimal('3.2')
+        with patch.object(Decimal, '__str__') as mock_str:
+            result = m / a
+            mock_str.assert_not_called()
+        assert result == Money('4.875', self.USD)
 
 
 class ExtendedMoney(Money):

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -9,7 +9,8 @@ import warnings
 
 import pytest  # Works with less code, more consistency than unittest.
 
-from moneyed.classes import Currency, Money, MoneyComparisonError, CURRENCIES, DEFAULT_CURRENCY, USD, get_currency, force_decimal
+from moneyed.classes import (Currency, Money, MoneyComparisonError, CURRENCIES,
+                             DEFAULT_CURRENCY, USD, get_currency, force_decimal)
 from moneyed.localization import format_money
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py26,py27,py32,py33,pypy,flake,checkmanifest
 [testenv]
 deps=
 	pytest
+	mock
 commands = py.test
 
 [testenv:flake]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist = py26,py27,py32,py33,pypy,flake,checkmanifest
 [testenv]
 deps=
 	pytest
-	mock
 commands = py.test
 
 [testenv:flake]


### PR DESCRIPTION
This pull request fixes an issue where Decimals are run through str() and then back to Decimal, when multiplying with a Money instance.

This makes the assumption that type casting a Decimal to a string, and back, is harmless.  But this is not necessarily true, and we might as well not do it if the number is already a Decimal instance.

In my particular use case, I have subclassed Decimal into a FormattedDecimal class, which displays at a different number of decimal places than it stores internally.  I have had to subclass pymoneyed.Money too in order to support this behaviour, just because it runs it through the str() method even when it doesn't need to.