### PR TITLE
Py-moneyed tested with Python 3.4.2. Everything is fine.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
 - TOXENV=py27
 - TOXENV=py32
 - TOXENV=py33
+- TOXENV=py34
 - TOXENV=pypy
 - TOXENV=flake
 - TOXENV=checkmanifest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Add to .travis.yml when you add to this
-envlist = py26,py27,py32,py33,pypy,flake,checkmanifest
+envlist = py26,py27,py32,py33,py34,pypy,flake,checkmanifest
 
 [testenv]
 deps=


### PR DESCRIPTION
Hi, I tested Py-moneyed with the Python version available in my computer, 3.4.2. Everything went fine, so, if it isn't necessary to test with every version on the 3.4 branch, here's the PR.