### PR TITLE
Use default locale to get sign if none set for current locale 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ Significant or incompatible changes listed here.
 Changes in development version
 ------------------------------
 
+Changes in v0.8
+---------------
+
+* DEFAULT locale is now used as a fallback to return a currency symbol if your chosen locale has no symbol set for that currency, rather than just returning the currency code.
+
+
 Changes in v0.7
 ---------------
 

--- a/moneyed/localization.py
+++ b/moneyed/localization.py
@@ -46,7 +46,8 @@ class CurrencyFormatter(object):
         if currency_code in local_set:
             return local_set.get(currency_code)
         else:
-            return ('', " %s" % currency_code)
+            ret = self.sign_definitions.get(DEFAULT).get(currency_code)
+            return ret if ret is not None else ('', " %s" % currency_code)
 
     def get_formatting_definition(self, locale):
         if locale.upper() not in self.formatting_definitions:

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -136,7 +136,7 @@ class TestMoney:
         one_million_pln = Money('1000000', 'PLN')
         # Two decimal places by default
         assert format_money(one_million_pln, locale='pl_PL') == '1 000 000,00 zł'
-        assert format_money(self.one_million_bucks, locale='pl_PL') == '1 000 000,00 USD'
+        assert format_money(self.one_million_bucks, locale='pl_PL') == 'US$1 000 000,00'
         # No decimal point without fractional part
         assert format_money(one_million_pln, locale='pl_PL',
                             decimal_places=0) == '1 000 000 zł'


### PR DESCRIPTION
If current locale has no set sign definition for a currency, fall back to using the `DEFAULT` locale to try to get the sign definition. Should fix #96. 

It looks like #38 was opened for a similar issue but was eventually merged into a separate branch. Is this something that would be kept in a different branch or do you want this functionality in the master?