### PR TITLE
Fix space placement in sv_SE prefix for SEK

### DIFF
--- a/moneyed/localization.py
+++ b/moneyed/localization.py
@@ -367,7 +367,7 @@ _sign(DEFAULT, moneyed.ZWL, prefix='Z$')
 
 _sign('en_US', moneyed.USD, prefix='$')
 _sign('en_GB', moneyed.GBP, prefix='£')
-_sign('sv_SE', moneyed.SEK, prefix=' kr')
+_sign('sv_SE', moneyed.SEK, prefix='kr ')
 _sign('pl_PL', moneyed.PLN, suffix=' zł')
 _sign('de_DE', moneyed.EUR, suffix=' €')
 _sign('de_AT', moneyed.EUR, suffix=' €')


### PR DESCRIPTION
It should be `kr 1 234,56`, not ` kr1 234,56`.