### PR TITLE
Add Norwegian localization

### DIFF
--- a/moneyed/localization.py
+++ b/moneyed/localization.py
@@ -189,6 +189,16 @@ _format("nl_NL", group_size=3, group_separator=".", decimal_point=",",
         negative_sign="-", trailing_negative_sign="",
         rounding_method=ROUND_HALF_EVEN)
 
+_format("nb_NO", group_size=3, group_separator=" ", decimal_point=",",
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
+_format("nn_NO", group_size=3, group_separator=" ", decimal_point=",",
+        positive_sign="", trailing_positive_sign="",
+        negative_sign="-", trailing_negative_sign="",
+        rounding_method=ROUND_HALF_EVEN)
+
 # CURRENCY SIGNS
 # Default currency signs. These can be overridden for locales where
 # foreign or local currency signs for one reason or another differ
@@ -379,6 +389,8 @@ _sign('fr_FR', moneyed.CAD, suffix=' $ CA')
 _sign('fr_CA', moneyed.CAD, suffix=' $')
 _sign('fr_CA', moneyed.EUR, suffix=' €')
 _sign('nl_NL', moneyed.EUR, prefix='€ ')
+_sign('nb_NO', moneyed.NOK, prefix='kr ')
+_sign('nn_NO', moneyed.NOK, prefix='kr ')
 
 # Adding translations for missing currencies
 _sign('en_US', moneyed.KWD, prefix='KD')


### PR DESCRIPTION
This adds Norwegian localization, both for "Norwegian bokmål" (nb_NO) and "Norwegian nynorsk" (nn_NO).

``` python
>>> from moneyed import NOK, Money
>>> from moneyed.localization import format_money
>>> m = Money(amount='1234.56', currency=NOK)
>>> format_money(m)
u'1,234.56 Nkr'
>>> format_money(m, locale='nb_NO')
u'kr 1 234,56'
>>> format_money(m, locale='nn_NO')
u'kr 1 234,56'
```