### PR TITLE
Fix Travis failing on tests, and add 3.6 testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,27 @@
 language: python
-# Make Python 3.5 available:
-python: 3.5
+# Make Python 3.5 and 3.6 available:
+python: 3.6
 # See tox.ini for env list
-env:
-- TOXENV=py26
-- TOXENV=py27
-- TOXENV=py32
-- TOXENV=py33
-- TOXENV=py34
-- TOXENV=py35
-- TOXENV=pypy
-- TOXENV=flake
-- TOXENV=checkmanifest
+matrix:
+  include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.2
+      env: TOXENV=py32
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: pypy
+      env: TOXENV=pypy
+    - env: TOXENV=flake
+    - env: TOXENV=checkmanifest
 install:
 - pip install tox>=2.1 'virtualenv<14'
 script:


### PR DESCRIPTION
Fixes Travis-CI failing on testing py2.6, 3.2, 3.3, pypy.
Also adds testing for py3.6.

![proof](https://user-images.githubusercontent.com/11885987/31104706-5b97b9fa-a7d6-11e7-993b-7000db3e28f5.PNG)
