### PR TITLE
Add Money.round([ndigits]) method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Significant or incompatible changes listed here.
 Changes in development version
 ------------------------------
 
+* ``Money.round([ndigits])`` added.
+  Uses ``decimal.ROUND_HALF_EVEN`` by default, but this can be overriden
+  by setting ``rounding`` in the ``decimal`` context before calling ``Money.round()``.
+
+
 Changes in v0.8
 ---------------
 

--- a/moneyed/classes.py
+++ b/moneyed/classes.py
@@ -155,6 +155,16 @@ class Money(object):
                 amount=(self.amount / force_decimal(other)),
                 currency=self.currency)
 
+    def round(self, ndigits=0):
+        """
+        Rounds the amount using the current ``Decimal`` rounding algorithm.
+        """
+        if ndigits is None:
+            ndigits = 0
+        return self.__class__(
+            amount=self.amount.quantize(Decimal('1e' + str(-ndigits))),
+            currency=self.currency)
+
     def __abs__(self):
         return self.__class__(
             amount=abs(self.amount),

--- a/moneyed/test_moneyed_classes.py
+++ b/moneyed/test_moneyed_classes.py
@@ -283,6 +283,34 @@ class TestMoney:
                      Money(amount=2, currency=self.USD)]) ==
                 Money(amount=3, currency=self.USD))
 
+    def test_round(self):
+        x = Money(amount='1234.33569', currency=self.USD)
+        assert x.round(-4) == Money(amount='0', currency=self.USD)
+        assert x.round(-3) == Money(amount='1000', currency=self.USD)
+        assert x.round(-2) == Money(amount='1200', currency=self.USD)
+        assert x.round(-1) == Money(amount='1230', currency=self.USD)
+        assert x.round(0) == Money(amount='1234', currency=self.USD)
+        assert x.round(None) == Money(amount='1234', currency=self.USD)
+        assert x.round(1) == Money(amount='1234.3', currency=self.USD)
+        assert x.round(2) == Money(amount='1234.34', currency=self.USD)
+        assert x.round(3) == Money(amount='1234.336', currency=self.USD)
+        assert x.round(4) == Money(amount='1234.3357', currency=self.USD)
+
+    def test_round_context_override(self):
+        import decimal
+
+        x = Money(amount='2.5', currency=self.USD)
+        assert x.round(0) == Money(amount=2, currency=self.USD)
+        x = Money(amount='3.5', currency=self.USD)
+        assert x.round(0) == Money(amount=4, currency=self.USD)
+
+        with decimal.localcontext() as ctx:
+            ctx.rounding = decimal.ROUND_HALF_UP
+            x = Money(amount='2.5', currency=self.USD)
+            assert x.round(0) == Money(amount=3, currency=self.USD)
+            x = Money(amount='3.5', currency=self.USD)
+            assert x.round(0) == Money(amount=4, currency=self.USD)
+
     def test_arithmetic_operations_return_real_subclass_instance(self):
         """
         Arithmetic operations on a subclass instance should return instances in the same subclass


### PR DESCRIPTION
Adds support for calling `round()` on Money instances.
Uses the default Python rounding algorithm.

The implementation uses Decimal.quantize under the hood to
ensure stable selection of rounding mode, and allows
the user to select their preferred mode by wrapping the call
in a decimal context suiting their needs.

Note that this feature is only supported on Python 3, as `__round__`-support seems to have been added only in 3.